### PR TITLE
Drop tensorflow_io from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 numpy
 tensorflow
-tensorflow_io


### PR DESCRIPTION
Missed this on the rush removal of tensorflow_io for M1 - sorry!