### PR TITLE
Fix returned number of samples and add some tests for dataloader

### DIFF
--- a/dataloader.py
+++ b/dataloader.py
@@ -59,10 +59,13 @@ class DataLoader:
         if self.n_samples is None:
             self.n_samples = len(useable_paths)
 
-        assert self.n_samples <= len(
+        # we need to get twice as many paths as requested samples (map and mask)
+        n_paths = self.n_samples * 2
+
+        assert n_paths <= len(
             useable_paths
         ), f"n_samples ({self.n_samples}) is greater than number of available/useable images."
-        useable_paths = useable_paths[: self.n_samples]
+        useable_paths = useable_paths[: n_paths]
 
         # split input and target
         input_paths = [filename for filename in useable_paths if "map" in filename]

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -1,6 +1,6 @@
+import unittest
 import math
 from dataloader import DataLoader
-import unittest
 
 
 class TestDataLoader(unittest.TestCase):
@@ -8,16 +8,41 @@ class TestDataLoader(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.path = "data/curated_1/test_curated_1_final/"
-        self.dataloader = DataLoader(self.path)
 
     def test_dataloader_returns_tfdataset_of_correct_shape(self):
-        self.dataloader.load()
+        dataloader = DataLoader(self.path, n_samples=10)
+        dataloader.load()
 
         # find the number of elements in the tensorflow dataset
-        length = math.ceil(self.dataloader._dataset_input.cardinality(
-        ).numpy() / self.dataloader.batch_size)
+        n_batches = math.ceil(dataloader._dataset_input.cardinality(
+        ).numpy() / dataloader.batch_size)
 
         # length = 2
-        for x, y in self.dataloader.dataset.take(length):
-            self.assertEqual(x.shape, (32, 224, 224, 3))
-            self.assertEqual(y.shape, (32, 224, 224))
+        for inputs, targets in dataloader.dataset.take(n_batches):
+            self.assertEqual(inputs.shape, (32, 224, 224, 3))
+            self.assertEqual(targets.shape, (32, 224, 224))
+
+    def test_dataloader_returns_requested_number_of_images(self):
+        dataloader = DataLoader(self.path, n_samples=10)
+        dataloader.load()
+        self.assertEqual(dataloader._dataset_input.cardinality().numpy(), 10)
+
+    def test_dataloader_raises_assert_error_too_many_images_requested(self):
+        with self.assertRaises(AssertionError):
+            DataLoader(self.path, n_samples=1_000_000_000)
+
+    def test_dataloader_returns_matching_pairs_map_mask(self):
+        dataloader = DataLoader(self.path, n_samples=100)
+
+        # find the number of elements in the tensorflow dataset
+        n_batches = math.ceil(dataloader._dataset_input
+                              .cardinality().numpy() / dataloader.batch_size)
+
+        map_paths = list(dataloader._dataset_input.take(n_batches))
+        mask_paths = list(dataloader._dataset_target.take(n_batches))
+
+        for map_path, mask_path in zip(map_paths, mask_paths):
+            self.assertEqual(
+                map_path.numpy().decode("utf-8").split("map"),
+                mask_path.numpy().decode("utf-8").split("mask")
+            )


### PR DESCRIPTION
Current main version returns half the amount of requested samples since it counts map and mask separately